### PR TITLE
Fix race condition on generating buf dynamic modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,11 @@ lazy val sbtBuf = project
     //console / initialCommands := "import com.yoppwork._",
     // set up 'scripted; sbt plugin for testing sbt plugins
     scriptedBufferLog := false,
-    scriptedLaunchOpts ++=
-      Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    scriptedLaunchOpts ++= Seq(
+      "-Xmx1024M",
+      "-Dplugin.version=" + version.value,
+      "-Dsbt.ivy.home=" + sbt.Keys.ivyPaths.value.ivyHome.getOrElse("~/.ivy2")
+    )
   )
 
 // TODO:  enable publishing

--- a/src/main/scala/com/yoppworks/sbt/SbtBufPlugin.scala
+++ b/src/main/scala/com/yoppworks/sbt/SbtBufPlugin.scala
@@ -18,9 +18,11 @@ import sbt.{
 }
 import sbtprotoc.ProtocPlugin
 import sbtprotoc.ProtocPlugin.autoImport.PB
+import sbt.ConcurrentRestrictions.Tag
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Future, blocking}
+import scala.util.Properties
 
 object SbtBufPlugin extends AutoPlugin {
 
@@ -46,10 +48,13 @@ object SbtBufPlugin extends AutoPlugin {
         taskKey[Option[File]]("Buf Module file for the primary source of this (sbt) module")
       val artifactDefinition = settingKey[Artifact]("Artifact definition for bug image artifact")
       val imageDir           = settingKey[File]("Target directory in which Buf image is generated")
+      val imageFile          = taskKey[File]("Generated Buf image file")
       val imageExt =
         settingKey[ImageExtension]("Format for Buf generate and published artifacts")
       val generateBufFiles =
         taskKey[Seq[File]]("Generate Buf files in each of the 'modules' managed by ScalaPB")
+
+      val Isolated = Tag("isolated")
 
       // against
       val againstImageDir =
@@ -81,6 +86,10 @@ object SbtBufPlugin extends AutoPlugin {
   }
 
   import autoImport.Buf.*
+
+  override lazy val globalSettings: Seq[Setting[_]] = Seq(
+    concurrentRestrictions += Tags.limit(Isolated, max = 1)
+  )
 
   override lazy val projectSettings = Seq(
     addImageArtifactToBuild := true,
@@ -201,45 +210,69 @@ object SbtBufPlugin extends AutoPlugin {
         moduleFiles :+ bufWorkspaceFile
       }
     },
-    generateBufImage := {
-      if (generateBufFiles.value.isEmpty) {
-        streams.value.log.debug(s"No Buf files generated, skipping Buf image generation")
-        None
-      } else {
-        val log          = streams.value.log
-        val imageDirFile = imageDir.value
-        if (!imageDirFile.exists()) {
-          IO.createDirectory(imageDirFile)
-        }
-        val image: File = imageDirFile / s"buf-workingdir-image.${imageExt.value}"
+    generateBufImage := Def
+      .task {
+        if (generateBufFiles.value.isEmpty) {
+          streams.value.log.debug(s"No Buf files generated, skipping Buf image generation")
+          None
+        } else {
+          val log = streams.value.log
+          val imageDirFile = imageDir.value
+          if (!imageDirFile.exists()) {
+            IO.createDirectory(imageDirFile)
+          }
+          val image: File = imageDirFile / s"buf-workingdir-image.${imageExt.value}"
 
-        import scala.sys.process.*
-        log.info(s"Building Buf image to ${image.getAbsolutePath}...")
-        val projectDir = baseDirectory.value
-        val bufBinary  = bufExecutable.value
-        val result = Process(
-          Seq(
-            bufBinary.getAbsolutePath,
-            "build",
-            projectDir.getAbsolutePath,
-            "-o",
-            image.getAbsolutePath
-          )
-        ) ! log
-        if (result != 0) {
-          log.error(s"Unexpected exit code from Buf build: ${result}")
-          throw new IllegalStateException("Buf build failed")
+          import scala.sys.process.*
+          log.info(s"Building Buf image to ${image.getAbsolutePath}...")
+          val projectDir = baseDirectory.value
+          val bufBinary = bufExecutable.value
+          val result = Process(
+            Seq(
+              bufBinary.getAbsolutePath,
+              "build",
+              projectDir.getAbsolutePath,
+              "-o",
+              image.getAbsolutePath
+            )
+          ) ! log
+          if (result != 0) {
+            log.error(s"Unexpected exit code from Buf build: ${result}")
+            throw new IllegalStateException("Buf build failed")
+          }
+          Some(image)
         }
-        Some(image)
       }
+      .tag(Tags.Compile, Isolated)
+      .value,
+    // To ensure that the image is generated in the same order as the compilation task compiles dependent modules.
+    Compile / compile := Def.taskDyn {
+      val result = (Compile / compile).value
+
+      if (hasBufSrcs.value) {
+        Def.task {
+          generateBufImage.value.getOrElse(
+            throw new IllegalStateException("Buf sources exist but no image was generated")
+          )
+          result
+        }
+      } else {
+        Def.task {
+          result
+        }
+      }
+    }.value,
+    imageFile := {
+      val imageDirFile = imageDir.value
+      if (!imageDirFile.exists())
+        IO.createDirectory(imageDirFile)
+      imageDirFile / s"buf-workingdir-image.${imageExt.value}"
     },
     packagedArtifacts := {
       if (addImageArtifactToBuild.value && hasBufSrcs.value)
         packagedArtifacts.value.updated(
           artifactDefinition.value,
-          generateBufImage.value.getOrElse(
-            throw new IllegalStateException("Buf sources exist but no image was generated")
-          )
+          imageFile.value
         )
       else packagedArtifacts.value
     },
@@ -262,6 +295,12 @@ object SbtBufPlugin extends AutoPlugin {
       binaryFile.setExecutable(true)
       binaryFile
     }
+  ) ++ Seq(
+    // override the protoc executable provided by the PROTOC environment variable or the one installed by Homebrew on M1 Macs,
+    // as the Mac M1 ARM compatible version of protoc is not yet published on Maven Central
+    PB.protocExecutable := (if (protocbridge.SystemDetector.detectedClassifier() == "osx-aarch_64")
+                              file(Properties.envOrElse("PROTOC", "/opt/homebrew/bin/protoc"))
+                            else PB.protocExecutable.value)
   )
 
   private def fetchAgainstTarget(

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/.gitignore
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/.gitignore
@@ -1,0 +1,2 @@
+target/
+global/

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/api/src/main/protobuf/pkg/v1/test.proto
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/api/src/main/protobuf/pkg/v1/test.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+import "kernel_pkg/v1/test.proto";
+
+package pkg.v1;
+
+option (scalapb.options) = {
+  single_file: true
+  retain_source_code_info: true
+  no_default_values_in_constructor: true
+  [scalapb.validate.file] {
+    validate_at_construction: false
+    insert_validator_instance: true
+  }
+};
+
+message TestType {
+  string value = 1  [(validate.rules).string = {
+    pattern: "[0-9]{10}$",
+    max_bytes: 10,
+  }];
+}
+
+message AnotherType {
+  string another_value = 1;
+  kernel_pkg.v1.KernelType k_type = 2;
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/build.sbt
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/build.sbt
@@ -1,0 +1,86 @@
+import sbt.Keys.scalaVersion
+import sbt.util
+
+ThisBuild / version := "0.0.1-SNAPSHOT"
+ThisBuild / scalaVersion := "2.13.7"
+
+val scalaPbDeps =  Seq(
+  "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
+  "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.3",
+  "com.thesamet.scalapb" %% "scalapb-validate-core" % scalapb.validate.compiler.BuildInfo.version % "protobuf"
+)
+
+lazy val external = project.in(file("./external"))
+  .settings(
+    name := "TestSbtBufHappyPathExternal",
+    libraryDependencies ++= scalaPbDeps,
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
+      scalapb.validate.gen() -> (Compile / sourceManaged).value / "scalapb"
+    )
+  )
+
+lazy val api = project.in(file("./api"))
+  .settings(
+    name := "TestSbtBufHappyPathApi",
+    libraryDependencies ++= scalaPbDeps,
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
+      scalapb.validate.gen() -> (Compile / sourceManaged).value / "scalapb"
+    )
+  )
+  .dependsOn(
+    kernel % "compile->compile;protobuf->protobuf"
+  )
+
+lazy val kernel = project.in(file("./kernel"))
+  .settings(
+    name := "TestSbtBufHappyPathKernel",
+    libraryDependencies ++= scalaPbDeps,
+    // Deliberately adding a delay to ensure that the Buf images are generated with the correct order of dependencies even though the Kernel module takes longer to compile and generate Buf images
+    (Compile / compile) := ((Compile / compile) dependsOn testDelayTask).value,
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
+      scalapb.validate.gen() -> (Compile / sourceManaged).value / "scalapb"
+    )
+  )
+
+/** Contains all possible protobuf dependency types: external module (mimicing another library), cross-module (against `api`) */
+lazy val client = project.in(file("./client"))
+  .settings(
+    name := "TestSbtBufHappyPathClient",
+    libraryDependencies ++= scalaPbDeps,
+    libraryDependencies += "testsbtbufhappypathexternal" %% "testsbtbufhappypathexternal" % "0.0.1-SNAPSHOT" % "compile;protobuf",
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
+      scalapb.validate.gen() -> (Compile / sourceManaged).value / "scalapb"
+    )
+  )
+  .dependsOn(
+    api % "compile->compile;protobuf->protobuf",
+    kernel % "compile->compile;protobuf->protobuf"
+  )
+
+val testEmptySourcesTask = TaskKey[Unit]("testEmptySourcesTask", "Task for asserting root module reports as containing no Buf/protobuf sources")
+/** Contains no proto sources or dependencies */
+lazy val service = project.in(file("."))
+  .settings(
+    name := "TestSbtHappyPathService",
+    libraryDependencies ++= scalaPbDeps,
+    libraryDependencies += "testsbtbufhappypathexternal" %% "testsbtbufhappypathexternal" % "0.0.1-SNAPSHOT" % "compile",
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
+      scalapb.validate.gen() -> (Compile / sourceManaged).value / "scalapb"
+    ),
+    testEmptySourcesTask := {
+      require(!Buf.hasBufSrcs.value, "Module should report no protobuf/Buf sources")
+      ()
+    }
+  )
+  .dependsOn(api % "compile->compile")
+  .aggregate(kernel, api, client)
+
+TaskKey[Unit]("checkEvicted") := {
+  require(evicted.value.allEvictions.isEmpty, "Eviction notices should be empty")
+  ()
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/build.sbt
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/build.sbt
@@ -37,8 +37,9 @@ lazy val kernel = project.in(file("./kernel"))
   .settings(
     name := "TestSbtBufHappyPathKernel",
     libraryDependencies ++= scalaPbDeps,
-    // Deliberately adding a delay to ensure that the Buf images are generated with the correct order of dependencies even though the Kernel module takes longer to compile and generate Buf images
-    (Compile / compile) := ((Compile / compile) dependsOn testDelayTask).value,
+    // Deliberately adding a delay to ensure that the Buf images are generated with the correct order of dependencies even
+    // though the Kernel module takes longer to compile and generate Buf images
+    Buf.generateBufFiles := (Buf.generateBufFiles dependsOn testDelayTask).value,
     Compile / PB.targets := Seq(
       scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
       scalapb.validate.gen() -> (Compile / sourceManaged).value / "scalapb"

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/client/src/main/protobuf/client_pkg/v1/test.proto
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/client/src/main/protobuf/client_pkg/v1/test.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+import "pkg/v1/test.proto";
+import "external_pkg/v1/external-test.proto";
+
+package client_pkg.v1;
+
+option (scalapb.options) = {
+  single_file: true
+  retain_source_code_info: true
+  no_default_values_in_constructor: true
+  [scalapb.validate.file] {
+    validate_at_construction: false
+    insert_validator_instance: true
+  }
+};
+
+message ClientType {
+  string value = 1  [(validate.rules).string = {
+    pattern: "[A-Za-z]{10}$",
+    max_bytes: 10,
+  }];
+  pkg.v1.AnotherType a_type = 2;
+  externalpkg.v1.ExternalType another_type = 3;
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/external/src/main/protobuf/external_pkg/v1/external-test.proto
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/external/src/main/protobuf/external_pkg/v1/external-test.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+
+package externalpkg.v1;
+
+option (scalapb.options) = {
+  single_file: true
+  retain_source_code_info: true
+  no_default_values_in_constructor: true
+  [scalapb.validate.file] {
+    validate_at_construction: false
+    insert_validator_instance: true
+  }
+};
+
+message ExternalType {
+  string value = 1  [(validate.rules).string = {
+    pattern: "^[0-9A-Z]{12}$",
+    max_bytes: 12,
+  }];
+}
+
+message AnotherExternalType {
+  int64 a_long = 1;
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/kernel/src/main/protobuf/kernel_pkg/v1/test.proto
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/kernel/src/main/protobuf/kernel_pkg/v1/test.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+import "validate/validate.proto";
+import "scalapb/scalapb.proto";
+import "scalapb/validate.proto";
+
+package kernel_pkg.v1;
+
+option (scalapb.options) = {
+  single_file: true
+  retain_source_code_info: true
+  no_default_values_in_constructor: true
+  [scalapb.validate.file] {
+    validate_at_construction: false
+    insert_validator_instance: true
+  }
+};
+
+message KernelType {
+  string value = 1  [(validate.rules).string = {
+    pattern: "[0-9]{10}$",
+    max_bytes: 10,
+  }];
+}
+
+message KernelAnotherType {
+  string another_value = 1;
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/project/TestTasksPlugin.scala
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/project/TestTasksPlugin.scala
@@ -15,6 +15,7 @@ object TestPlugin extends AutoPlugin {
     val action: (State, String) => State = {
       (state,expectedOrder) =>
         val order = orderOfGeneratingBufImages.get().mkString(",")
+        state.log.info(s"Order of generated buf images: ${order}")
         require(order == expectedOrder,s"Order of generating Buf images is not correct, expected $expectedOrder, but got $order")
         state
     }

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/project/TestTasksPlugin.scala
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/project/TestTasksPlugin.scala
@@ -1,0 +1,35 @@
+import sbt._
+import Keys._
+import java.util.concurrent.atomic.AtomicReference
+import com.yoppworks.sbt.SbtBufPlugin
+import com.yoppworks.sbt.SbtBufPlugin.autoImport.Buf._
+
+object TestPlugin extends AutoPlugin {
+  override def requires = SbtBufPlugin
+  override def trigger = allRequirements
+  lazy val orderOfGeneratingBufImages = new AtomicReference[List[String]](List.empty[String])
+
+  object autoImport {
+    val testDelayTask = TaskKey[Unit]("delay", "Task for adding a time delay")
+
+    val action: (State, String) => State = {
+      (state,expectedOrder) =>
+        val order = orderOfGeneratingBufImages.get().mkString(",")
+        require(order == expectedOrder,s"Order of generating Buf images is not correct, expected $expectedOrder, but got $order")
+        state
+    }
+    val expectedOrderOfModules: Command = Command.single("expectedOrderOfModules")(action)
+  }
+  import autoImport._
+
+  override lazy val projectSettings = Seq(
+    testDelayTask := {
+      Thread.sleep(1000)
+    },
+    generateBufImage := {
+      orderOfGeneratingBufImages.updateAndGet(_ :+ name.value)
+      generateBufImage.value
+    },
+    commands ++= Seq(expectedOrderOfModules)
+  )
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/project/plugins.sbt
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/project/plugins.sbt
@@ -1,0 +1,12 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.yoppworks.sbt" % """sbt-buf""" % pluginVersion)
+}
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.4")
+libraryDependencies ++= Seq(
+  "com.thesamet.scalapb" %% "compilerplugin" % "0.11.8",
+  "com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.2"
+)

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/src/main/scala/package/Main.scala
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/src/main/scala/package/Main.scala
@@ -1,0 +1,6 @@
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("starting service....")
+  }
+}

--- a/src/sbt-test/sbt-buf/complex-dependent-modules/test
+++ b/src/sbt-test/sbt-buf/complex-dependent-modules/test
@@ -1,0 +1,31 @@
+# Setup repository.
+$ exec git init
+$ exec git config user.email "email"
+$ exec git config user.name "name"
+$ exec git add .gitignore
+$ exec git add .
+$ exec git commit -m 'initial commit'
+# build buf image
+# version published at 0.0.1-SNAPSHOT
+> external/publishLocal
+> publishLocal
+> testEmptySourcesTask
+# assert buf files were created
+$ exec test -f client/src/main/protobuf/buf.yaml
+$ exec test -f client/target/protobuf_external/buf.yaml
+$ exec test -f client/buf.work.yaml
+$ exec test -f api/src/main/protobuf/buf.yaml
+$ exec test -f api/target/protobuf_external/buf.yaml
+$ exec test -f api/buf.work.yaml
+# assert no files were generated for the root module, which has no sources
+-$ exec test -f src/main/protobuf/buf.yaml
+-$ exec test -f target/protobuf_external/buf.yaml
+-$ exec test -f buf.work.yaml
+# assert buf image was created
+$ exec test -f client/target/buf/buf-workingdir-image.bin
+$ exec test -f api/target/buf/buf-workingdir-image.bin
+# assert no image was generated for root module without sources
+-$ exec test -f target/buf/buf-workingdir-image.bin
+> expectedOrderOfModules TestSbtBufHappyPathExternal,TestSbtBufHappyPathKernel,TestSbtBufHappyPathApi,TestSbtBufHappyPathClient
+
+


### PR DESCRIPTION
Builds on the excellent test harness and cases provided in #2, but swaps in a less 'invasive' implementation to satisfy the test conditions.

Rather than 'hitching' the `generateBufFiles` tasks to the compile task (in theory there is no functional/logical reason to have them coupled), this solution defines a `dependsOn` relation between any `generateBufFiles` task between dependent modules, which has the effect of ensuring the correct ordering of dependent modules.

Recommended to review with "hide whitespace" feature enabled to see the simplicity of the solution.

Addresses #1 