### PR TITLE
Issue #10 buf compat check race condition

### DIFF
--- a/src/main/scala/com/yoppworks/sbt/SbtBufPlugin.scala
+++ b/src/main/scala/com/yoppworks/sbt/SbtBufPlugin.scala
@@ -386,7 +386,14 @@ object SbtBufPlugin extends AutoPlugin {
             log.info("Buf breaking change detection passed successfully!")
           }
       }
-    }
+    }.dependsOn(
+      generateBufFiles.?.all(
+        ScopeFilter(
+          inDependencies(ThisProject, transitive = false),
+          inConfigurations(Compile)
+        )
+      )
+    )
   }
 
   private def runBufLint(): Def.Initialize[InputTask[Unit]] = {

--- a/src/sbt-test/sbt-buf/complex/test
+++ b/src/sbt-test/sbt-buf/complex/test
@@ -30,6 +30,10 @@ $ exec test -f api/target/buf/buf-workingdir-image.bin
 > bufLint
 # test successful buf compat check (with no changes)
 > bufCompatCheck 0.0.1-SNAPSHOT
+# clear out virtual buf module files to test fix for race condition between bufCompatCheck and generateBufFiles
+$ exec git clean -df
+# execute bufCompatCheck to exercise race condition between bufCompatCheck and generateBufFiles
+> bufCompatCheck 0.0.1-SNAPSHOT
 # make some changes to the proto message to introduce a linting error (camel case vs snake-case), and a breaking change (field type change)
 $ exec sed -i'' 's/string another_value/int32 anotherValue/g' api/src/main/protobuf/pkg/v1/test.proto
 # should fail due to camel case variable name


### PR DESCRIPTION
`bufCompatCheck` task suffered from a race condition by way of implicitly but not explicitly depending on `generateBufFiles`. `bufCompatCheck` does depend on `buildBufImage`, which calls `generateBufFiles`, but all through implicit `task.value` references, and no explicitly declared task dependencies.  This resulted in the `bufCompatCheck` looking for the virtual module file before it had been generated by `generateBufFiles`, leading to an exception.  

This MR introduces a few commands to the `complex` test case to demonstrate the problem, and an explicit task dependency defined on `bufCompatCheck` -> `generateBufFiles`, which addresses the issue.

Addresses #10 